### PR TITLE
Localize frontend UI to Chinese

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>WordPecker 词汇应用</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/AddWordModal.tsx
+++ b/frontend/src/components/AddWordModal.tsx
@@ -39,7 +39,7 @@ export const AddWordModal = ({ isOpen, onClose, onAddWord }: AddWordModalProps) 
   const handleSubmit = async () => {
     if (!word.trim()) {
       toast({
-        title: 'Word is required',
+        title: '必须输入单词',
         status: 'error',
         duration: 2000,
         isClosable: true,
@@ -51,8 +51,8 @@ export const AddWordModal = ({ isOpen, onClose, onAddWord }: AddWordModalProps) 
     try {
       await onAddWord(word.trim());
       toast({
-        title: '🪵 Word found!',
-        description: 'Finding the perfect meaning for your word...',
+        title: '🪵 找到单词！',
+        description: '正在为你查找最佳释义...',
         status: 'success',
         duration: 2000,
         isClosable: true,
@@ -61,8 +61,8 @@ export const AddWordModal = ({ isOpen, onClose, onAddWord }: AddWordModalProps) 
       onClose();
     } catch (error) {
       toast({
-        title: 'Failed to add word',
-        description: error instanceof Error ? error.message : 'Unknown error occurred',
+        title: '添加单词失败',
+        description: error instanceof Error ? error.message : '发生未知错误',
         status: 'error',
         duration: 2000,
         isClosable: true,
@@ -101,7 +101,7 @@ export const AddWordModal = ({ isOpen, onClose, onAddWord }: AddWordModalProps) 
                 bgClip="text"
                 fontSize="2xl"
               >
-                Find a New Word 🪵
+                发现新单词 🪵
               </Text>
             </Flex>
           </ModalHeader>
@@ -109,9 +109,9 @@ export const AddWordModal = ({ isOpen, onClose, onAddWord }: AddWordModalProps) 
           <ModalBody>
             <VStack spacing={4}>
               <FormControl isRequired>
-                <FormLabel color="gray.300">Word to Find</FormLabel>
+                <FormLabel color="gray.300">要查找的单词</FormLabel>
                 <Input
-                  placeholder="Type a word to add to your tree..."
+                  placeholder="输入要添加到词汇树的单词..."
                   value={word}
                   onChange={(e) => setWord(e.target.value)}
                   onKeyPress={handleKeyPress}
@@ -129,14 +129,14 @@ export const AddWordModal = ({ isOpen, onClose, onAddWord }: AddWordModalProps) 
 
           <ModalFooter gap={2}>
             <Button variant="ghost" onClick={onClose} color="gray.300">
-              Cancel
+              取消
             </Button>
             <Button
               variant="solid"
               colorScheme="orange"
               onClick={handleSubmit}
               isLoading={isLoading}
-              loadingText="Finding word 🪵"
+              loadingText="正在查找单词 🪵"
               leftIcon={<Icon as={FaSearch} boxSize={5} />}
               _hover={{
                 transform: 'translateY(-2px)',
@@ -144,7 +144,7 @@ export const AddWordModal = ({ isOpen, onClose, onAddWord }: AddWordModalProps) 
               }}
               transition="all 0.2s"
             >
-              Find Word
+              查找单词
             </Button>
           </ModalFooter>
         </MotionBox>

--- a/frontend/src/components/CreateListModal.tsx
+++ b/frontend/src/components/CreateListModal.tsx
@@ -101,7 +101,7 @@ export const CreateListModal = ({ isOpen, onClose, onCreateList }: CreateListMod
                 bgClip="text"
                 fontSize="2xl"
               >
-                Plant New Word Tree ✨
+                种下新的词汇树 ✨
               </Text>
             </Flex>
           </ModalHeader>
@@ -109,9 +109,9 @@ export const CreateListModal = ({ isOpen, onClose, onCreateList }: CreateListMod
           <ModalBody>
             <VStack spacing={4}>
               <FormControl isRequired>
-                <FormLabel color="gray.300">Tree Name</FormLabel>
+                <FormLabel color="gray.300">词汇树名称</FormLabel>
                 <Input
-                  placeholder="Name your word tree..."
+                  placeholder="给你的词汇树起个名字..."
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   onKeyPress={handleKeyPress}
@@ -125,9 +125,9 @@ export const CreateListModal = ({ isOpen, onClose, onCreateList }: CreateListMod
                 />
               </FormControl>
               <FormControl>
-                <FormLabel color="gray.300">Description</FormLabel>
+                <FormLabel color="gray.300">描述</FormLabel>
                 <Textarea
-                  placeholder="What kind of words will grow on this tree?"
+                  placeholder="这棵词汇树将包含哪些单词？"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   bg="slate.700"
@@ -141,9 +141,9 @@ export const CreateListModal = ({ isOpen, onClose, onCreateList }: CreateListMod
               <FormControl>
                 <FormLabel color="gray.300">
                   <Flex align="center" gap={2}>
-                    <Text>Tree Roots</Text>
+                    <Text>词汇树根基</Text>
                     <Tooltip 
-                      label="What's the foundation of this word tree? (e.g., Medical Terms, Computer Science, Literature)"
+                      label="这棵词汇树的基础是什么？（例如：医学术语、计算机科学、文学等）"
                       placement="top"
                       hasArrow
                     >
@@ -152,7 +152,7 @@ export const CreateListModal = ({ isOpen, onClose, onCreateList }: CreateListMod
                   </Flex>
                 </FormLabel>
                 <Textarea
-                  placeholder="e.g., Medical Terms, Computer Science, Harry Potter Series..."
+                  placeholder="例如：医学术语、计算机科学、哈利波特系列..."
                   value={context}
                   onChange={(e) => setContext(e.target.value)}
                   bg="slate.700"
@@ -168,14 +168,14 @@ export const CreateListModal = ({ isOpen, onClose, onCreateList }: CreateListMod
 
           <ModalFooter gap={2}>
             <Button variant="ghost" onClick={onClose} color="gray.300">
-              Cancel
+              取消
             </Button>
             <Button
               variant="solid"
               colorScheme="green"
               onClick={handleSubmit}
               isLoading={isLoading}
-              loadingText="Planting tree ✨"
+              loadingText="正在种树 ✨"
               leftIcon={<Icon as={GiTreeRoots} boxSize={5} />}
               _hover={{
                 transform: 'translateY(-2px)',
@@ -183,7 +183,7 @@ export const CreateListModal = ({ isOpen, onClose, onCreateList }: CreateListMod
               }}
               transition="all 0.2s"
             >
-              Plant Tree
+              种下词汇树
             </Button>
           </ModalFooter>
         </MotionBox>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -20,7 +20,7 @@ export const Header = () => {
                 transition="all 0.2s"
               >
                 <Flex align="center" gap={1}>
-                  <Text>My Trees</Text>
+                  <Text>我的单词树</Text>
                   <Icon 
                     as={FaFeatherAlt} 
                     color="#FA8C16" 
@@ -42,7 +42,7 @@ export const Header = () => {
                 }}
                 transition="all 0.2s"
               >
-                Templates
+                模板库
               </Button>
             </Link>
             <Link to="/describe">
@@ -55,7 +55,7 @@ export const Header = () => {
                 }}
                 transition="all 0.2s"
               >
-                Vision Garden
+                视觉花园
               </Button>
             </Link>
             <Link to="/learn-new-words">
@@ -68,7 +68,7 @@ export const Header = () => {
                 }}
                 transition="all 0.2s"
               >
-                Get New Words
+                获取新词
               </Button>
             </Link>
             <Link to="/settings">
@@ -81,13 +81,13 @@ export const Header = () => {
                 }}
                 transition="all 0.2s"
               >
-                Settings
+                设置
               </Button>
             </Link>
           </Flex>
           <Box>
             <Text color="green.500" fontWeight="bold">
-              WordPecker App
+              WordPecker 应用
             </Text>
           </Box>
         </Flex>

--- a/frontend/src/pages/ListDetail.tsx
+++ b/frontend/src/pages/ListDetail.tsx
@@ -121,7 +121,7 @@ export const ListDetail = () => {
       const newWord = await apiService.addWord(id!, word);
       setWords(prevWords => [newWord, ...prevWords]);
       toast({
-        title: 'Word added successfully',
+        title: '单词添加成功',
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -130,8 +130,8 @@ export const ListDetail = () => {
     } catch (error) {
       console.error('Error adding word:', error);
       toast({
-        title: 'Error adding word',
-        description: 'Please try again later',
+        title: '添加单词失败',
+        description: '请稍后再试',
         status: 'error',
         duration: 5000,
         isClosable: true,
@@ -144,7 +144,7 @@ export const ListDetail = () => {
       await apiService.deleteWord(id!, wordId);
       setWords(prevWords => prevWords.filter(word => word.id !== wordId));
       toast({
-        title: 'Word deleted successfully',
+        title: '单词删除成功',
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -152,8 +152,8 @@ export const ListDetail = () => {
     } catch (error) {
       console.error('Error deleting word:', error);
       toast({
-        title: 'Error deleting word',
-        description: 'Please try again later',
+        title: '删除单词失败',
+        description: '请稍后再试',
         status: 'error',
         duration: 5000,
         isClosable: true,
@@ -162,12 +162,12 @@ export const ListDetail = () => {
   };
 
   const handleDeleteList = async () => {
-    if (!id || !window.confirm('Are you sure you want to delete this list? This action cannot be undone.')) return;
+    if (!id || !window.confirm('确定要删除该列表吗？此操作无法撤销。')) return;
     
     try {
       await apiService.deleteList(id);
       toast({
-        title: 'List deleted successfully',
+        title: '列表删除成功',
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -176,8 +176,8 @@ export const ListDetail = () => {
     } catch (error) {
       console.error('Error deleting list:', error);
       toast({
-        title: 'Error deleting list',
-        description: 'Please try again later',
+        title: '删除列表失败',
+        description: '请稍后再试',
         status: 'error',
         duration: 5000,
         isClosable: true,
@@ -205,8 +205,8 @@ export const ListDetail = () => {
     } catch (error) {
       console.error('Error generating light reading:', error);
       toast({
-        title: 'Error generating reading',
-        description: 'Please try again later',
+        title: '生成阅读失败',
+        description: '请稍后再试',
         status: 'error',
         duration: 5000,
         isClosable: true,
@@ -228,13 +228,13 @@ export const ListDetail = () => {
     return (
       <Container maxW="container.xl" py={8} px={{ base: 4, md: 8 }}>
         <Box textAlign="center" py={10}>
-          <Text>List not found</Text>
+          <Text>未找到该词汇列表</Text>
           <Button 
             onClick={() => navigate('/lists')} 
             mt={4}
             colorScheme="green"
           >
-            Back to Lists
+            返回列表
           </Button>
         </Box>
       </Container>
@@ -331,7 +331,7 @@ export const ListDetail = () => {
               isDisabled={words.length === 0}
               onClick={() => navigate(`/learn/${list!.id}`, { state: { list } })}
             >
-              Learn
+              学习
             </Button>
             <Button 
               variant="ghost"
@@ -345,7 +345,7 @@ export const ListDetail = () => {
               isDisabled={words.length === 0}
               onClick={() => navigate(`/quiz/${list!.id}`, { state: { list } })}
             >
-              Quiz
+              测验
             </Button>
             <Button 
               variant="ghost"
@@ -359,7 +359,7 @@ export const ListDetail = () => {
               isDisabled={words.length === 0}
               onClick={onReadingModalOpen}
             >
-              Light Reading
+              简易阅读
             </Button>
             <Button 
               variant="ghost"
@@ -386,7 +386,7 @@ export const ListDetail = () => {
                 } 
               })}
             >
-              Voice Chat
+              语音聊天
             </Button>
             <Button 
               variant="solid"
@@ -399,7 +399,7 @@ export const ListDetail = () => {
               size="lg"
               onClick={onOpen}
             >
-              Add Word
+              添加单词
             </Button>
           </Flex>
         </Flex>
@@ -428,7 +428,7 @@ export const ListDetail = () => {
                 style={{ animation: 'sparkle 3s ease infinite' }}
               />
               <Text color="gray.400" fontSize="lg" textAlign="center">
-                Your tree is empty! Add some words to help it grow. 🌱
+                这棵词汇树还是空的，添加单词让它成长吧 🌱
               </Text>
               <Button
                 variant="outline"
@@ -441,7 +441,7 @@ export const ListDetail = () => {
                 }}
                 transition="all 0.2s"
               >
-                Add Your First Word
+                添加你的第一个单词
               </Button>
             </Flex>
           ) : (
@@ -549,19 +549,19 @@ export const ListDetail = () => {
             <ModalHeader>
               <Flex align="center" gap={2}>
                 <FaBookOpen color="purple" />
-                <Text color="purple.400">Generate Light Reading</Text>
+                <Text color="purple.400">生成简易阅读</Text>
               </Flex>
             </ModalHeader>
             <ModalCloseButton />
             <ModalBody>
               <VStack spacing={4} align="stretch">
                 <Text fontSize="sm" color="gray.400">
-                  Create a personalized reading passage using the words from "{list?.name}". 
-                  Choose your preferred difficulty level:
+                  使用 "{list?.name}" 中的词汇生成个性化阅读材料。
+                  请选择难度等级：
                 </Text>
                 
                 <FormControl>
-                  <FormLabel color="purple.300">Reading Level</FormLabel>
+                  <FormLabel color="purple.300">阅读难度</FormLabel>
                   <Select 
                     value={lightReadingLevel} 
                     onChange={(e) => setLightReadingLevel(e.target.value as 'beginner' | 'intermediate' | 'advanced')}
@@ -569,33 +569,33 @@ export const ListDetail = () => {
                     borderColor="slate.600"
                     _focus={{ borderColor: 'purple.400' }}
                   >
-                    <option value="beginner">Beginner - Simple sentences and basic vocabulary</option>
-                    <option value="intermediate">Intermediate - Natural flow with moderate complexity</option>
-                    <option value="advanced">Advanced - Complex sentences and sophisticated language</option>
+                    <option value="beginner">初级 - 简单句子和基础词汇</option>
+                    <option value="intermediate">中级 - 语句自然、难度适中</option>
+                    <option value="advanced">高级 - 复杂句子和高级用语</option>
                   </Select>
                 </FormControl>
 
                 <Box p={3} bg="purple.50" borderRadius="md" borderLeft="4px solid" borderColor="purple.400">
                   <Text fontSize="sm" color="purple.700">
-                    💡 The reading will include {Math.min(12, words.length)} randomly selected words from your list 
-                    {words.length > 12 && ` (out of ${words.length} total)`} in a contextual story or article
-                    {list?.context && ` related to "${list.context}"`}.
+                    💡 阅读材料将包含 {Math.min(12, words.length)} 个随机选择的单词
+                    {words.length > 12 && `（共 ${words.length} 个）`}，并结合相关情境文章
+                    {list?.context && `（主题：${list.context}）`}。
                   </Text>
                 </Box>
               </VStack>
             </ModalBody>
             <ModalFooter>
               <Button variant="ghost" mr={3} onClick={onReadingModalClose}>
-                Cancel
+                取消
               </Button>
               <Button
                 colorScheme="purple"
                 onClick={handleGenerateLightReading}
                 isLoading={generatingReading}
-                loadingText="Creating Reading..."
+                loadingText="正在生成阅读材料..."
                 leftIcon={<FaBookOpen />}
               >
-                Generate Reading
+                生成阅读
               </Button>
             </ModalFooter>
           </ModalContent>

--- a/frontend/src/pages/Lists.tsx
+++ b/frontend/src/pages/Lists.tsx
@@ -58,8 +58,8 @@ export const Lists = () => {
       } catch (error) {
         console.error('Error fetching lists:', error);
         toast({
-          title: 'Error fetching lists',
-          description: 'Please try again later',
+          title: '获取列表失败',
+          description: '请稍后再试',
           status: 'error',
           duration: 5000,
           isClosable: true,
@@ -78,7 +78,7 @@ export const Lists = () => {
       setLists(prevLists => [newList, ...prevLists]);
       // Word count and progress are now included in the API response
       toast({
-        title: 'List created successfully',
+        title: '列表创建成功',
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -87,8 +87,8 @@ export const Lists = () => {
     } catch (error) {
       console.error('Error creating list:', error);
       toast({
-        title: 'Error creating list',
-        description: 'Please try again later',
+        title: '创建列表失败',
+        description: '请稍后再试',
         status: 'error',
         duration: 5000,
         isClosable: true,
@@ -139,10 +139,10 @@ export const Lists = () => {
                   mt={-4}
                 />
               </Flex>
-              My Word Trees
+              我的单词树
             </Heading>
             <Text mt={2} color="gray.400" fontSize="lg">
-              Plant and grow your vocabulary with WordPecker! 🌱
+              在 WordPecker 中种下并培育你的词汇树！🌱
             </Text>
           </Box>
           <Button
@@ -157,7 +157,7 @@ export const Lists = () => {
             transition="all 0.2s"
             w={{ base: 'full', md: 'auto' }}
           >
-            Plant New Tree
+            种下新的词汇树
           </Button>
         </Flex>
 
@@ -219,7 +219,7 @@ export const Lists = () => {
                               fontSize="xs"
                               noOfLines={1}
                             >
-                              My Word Tree
+                              我的词汇树
                             </Text>
                           </VStack>
                         </Flex>
@@ -236,7 +236,7 @@ export const Lists = () => {
                             w="full"
                             textAlign="center"
                           >
-                            {wordCount} words
+                            {wordCount} 个词汇
                           </Badge>
                           {wordCount > 0 && list.masteredWords && list.masteredWords > 0 && (
                             <Badge 
@@ -299,7 +299,7 @@ export const Lists = () => {
                           isDisabled={wordCount === 0}
                           size="md"
                         >
-                          Learn
+                          学习
                         </Button>
                       </Link>
                       <Link to={`/quiz/${list.id}`} style={{ flex: 1 }}>
@@ -316,7 +316,7 @@ export const Lists = () => {
                           isDisabled={wordCount === 0}
                           size="md"
                         >
-                          Quiz
+                          测验
                         </Button>
                       </Link>
                       <Link to={`/lists/${list.id}`} style={{ flex: 1 }}>
@@ -332,7 +332,7 @@ export const Lists = () => {
                           transition="all 0.2s"
                           size="md"
                         >
-                          View
+                          查看
                         </Button>
                         </Link>
                       </Flex>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -119,8 +119,8 @@ export const Settings: React.FC = () => {
     } catch (error) {
       console.error('Failed to load preferences:', error);
       toast({
-        title: 'Error',
-        description: 'Failed to load preferences. Using default settings.',
+        title: '错误',
+        description: '加载偏好设置失败，已使用默认设置。',
         status: 'warning',
         duration: 3000,
         isClosable: true,
@@ -210,7 +210,7 @@ export const Settings: React.FC = () => {
         languageCode: null,
         standardizedName: null,
         parameters: null,
-        explanation: 'Failed to validate language. Please try again.'
+        explanation: '语言验证失败，请重试。'
       });
     } finally {
       setValidating(false);
@@ -279,8 +279,8 @@ export const Settings: React.FC = () => {
       
       if (!finalBaseValid || !finalTargetValid) {
         toast({
-          title: 'Invalid Languages',
-          description: 'Please ensure both languages are valid before saving.',
+          title: '语言无效',
+          description: '请确认两种语言均有效后再保存。',
           status: 'error',
           duration: 3000,
           isClosable: true,
@@ -293,8 +293,8 @@ export const Settings: React.FC = () => {
     try {
       await apiService.updatePreferences(preferences);
       toast({
-        title: 'Success',
-        description: 'Preferences saved successfully!',
+        title: '成功',
+        description: '偏好设置已保存！',
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -302,8 +302,8 @@ export const Settings: React.FC = () => {
     } catch (error) {
       console.error('Failed to save preferences:', error);
       toast({
-        title: 'Error',
-        description: 'Failed to save preferences. Please try again.',
+        title: '错误',
+        description: '保存偏好设置失败，请重试。',
         status: 'error',
         duration: 3000,
         isClosable: true,
@@ -332,11 +332,11 @@ export const Settings: React.FC = () => {
           <HStack spacing={3} mb={2}>
             <Text fontSize="2xl">⚙️</Text>
             <Heading size="xl" color="blue.500">
-              Settings
+              设置
             </Heading>
           </HStack>
           <Text color="gray.600" fontSize="lg">
-            Customize your learning experience
+            自定义你的学习体验
           </Text>
         </Box>
 
@@ -346,19 +346,19 @@ export const Settings: React.FC = () => {
             <VStack align="start" spacing={3}>
               <HStack spacing={3}>
                 <Text fontSize="2xl">🌍</Text>
-                <Heading size="md" color="blue.500">Language Settings</Heading>
+                <Heading size="md" color="blue.500">语言设置</Heading>
               </HStack>
               <Text color={useColorModeValue('gray.700', 'gray.300')} fontSize="md" lineHeight="1.6">
-                Choose your native language and the language you want to learn. This affects how vocabulary definitions and explanations are presented.
+                选择你的母语以及要学习的目标语言，这将影响词汇释义和说明的呈现方式。
               </Text>
               <Alert status="info" borderRadius="md" py={3}>
                 <AlertIcon />
                 <VStack align="start" spacing={2}>
                   <Text fontSize="sm" fontWeight="medium" color={useColorModeValue('blue.800', 'blue.200')}>
-                    Changes will apply immediately to new vocabulary words and exercises.
+                    更改会立即应用于新的词汇和练习。
                   </Text>
                   <Text fontSize="sm" color={useColorModeValue('gray.700', 'gray.300')}>
-                    💡 You can specify variants like "Japanese with Hiragana", "Simplified Chinese", "Brazilian Portuguese", "American English", etc.
+                    💡 你可以指定 "带假名的日语"、"简体中文"、"巴西葡萄牙语"、"美式英语" 等语言变体。
                   </Text>
                 </VStack>
               </Alert>
@@ -369,13 +369,13 @@ export const Settings: React.FC = () => {
               <Box p={4} bg={useColorModeValue('blue.50', 'blue.900')} borderRadius="lg" borderWidth="1px" borderColor={useColorModeValue('blue.200', 'blue.700')}>
                 <FormControl isInvalid={baseLanguageValidation?.isValid === false}>
                   <FormLabel fontWeight="semibold" fontSize="md" color={useColorModeValue('blue.700', 'blue.200')}>
-                    🏠 Your Native Language (Base Language)
+                    🏠 你的母语（基础语言）
                   </FormLabel>
                   <HStack spacing={3}>
                     <Input
                       value={baseLanguageInput}
                       onChange={(e) => handleBaseLanguageChange(e.target.value)}
-                      placeholder="e.g., English, American English, Turkish, etc."
+                      placeholder="例如：英语、美式英语、土耳其语等"
                       bg={useColorModeValue('white', 'gray.800')}
                       flex={1}
                       borderColor={useColorModeValue('blue.300', 'blue.600')}
@@ -385,14 +385,14 @@ export const Settings: React.FC = () => {
                     <Button
                       onClick={handleValidateBaseLanguage}
                       isLoading={validatingBaseLanguage}
-                      loadingText="Validating"
+                      loadingText="验证中"
                       colorScheme="cyan"
                       variant="solid"
                       size="md"
                       isDisabled={!baseLanguageInput.trim()}
                       minW="100px"
                     >
-                      Validate
+                      验证
                     </Button>
                   </HStack>
                   {baseLanguageValidation?.isValid && (
@@ -421,7 +421,7 @@ export const Settings: React.FC = () => {
                     </Box>
                   )}
                   <FormHelperText mt={3} color={useColorModeValue('gray.600', 'gray.400')}>
-                    Definitions and explanations will be provided in this language
+                    释义和说明将使用此语言提供
                   </FormHelperText>
                 </FormControl>
               </Box>
@@ -429,13 +429,13 @@ export const Settings: React.FC = () => {
               <Box p={4} bg={useColorModeValue('green.50', 'green.900')} borderRadius="lg" borderWidth="1px" borderColor={useColorModeValue('green.200', 'green.700')}>
                 <FormControl isInvalid={targetLanguageValidation?.isValid === false}>
                   <FormLabel fontWeight="semibold" fontSize="md" color={useColorModeValue('green.700', 'green.200')}>
-                    🎯 Language You're Learning (Target Language)
+                    🎯 你正在学习的语言（目标语言）
                   </FormLabel>
                   <HStack spacing={3}>
                     <Input
                       value={targetLanguageInput}
                       onChange={(e) => handleTargetLanguageChange(e.target.value)}
-                      placeholder="e.g., Japanese with Hiragana, Simplified Chinese, Brazilian Portuguese, etc."
+                      placeholder="例如：带假名的日语、简体中文、巴西葡萄牙语等"
                       bg={useColorModeValue('white', 'gray.800')}
                       flex={1}
                       borderColor={useColorModeValue('green.300', 'green.600')}
@@ -445,14 +445,14 @@ export const Settings: React.FC = () => {
                     <Button
                       onClick={handleValidateTargetLanguage}
                       isLoading={validatingTargetLanguage}
-                      loadingText="Validating"
+                      loadingText="验证中"
                       colorScheme="green"
                       variant="solid"
                       size="md"
                       isDisabled={!targetLanguageInput.trim()}
                       minW="100px"
                     >
-                      Validate
+                      验证
                     </Button>
                   </HStack>
                   {targetLanguageValidation?.isValid && (
@@ -507,12 +507,12 @@ export const Settings: React.FC = () => {
                 <Heading size="md" color="blue.500">Exercise Types</Heading>
               </HStack>
               <Text color={useColorModeValue('gray.700', 'gray.300')} fontSize="md" lineHeight="1.6">
-                Choose which types of exercises you want to practice. You can enable or disable specific question formats.
+                选择你想练习的练习类型，可启用或禁用特定的题型。
               </Text>
               <Alert status="info" borderRadius="md" py={3}>
                 <AlertIcon />
                 <Text fontSize="sm" fontWeight="medium" color={useColorModeValue('blue.800', 'blue.200')}>
-                  Changes will apply to new learning sessions and quizzes.
+                  更改将应用于新的学习和测验。
                 </Text>
               </Alert>
             </VStack>
@@ -594,7 +594,7 @@ export const Settings: React.FC = () => {
                 colorScheme="blue"
                 onClick={savePreferences}
                 isLoading={saving}
-                loadingText="Saving..."
+                loadingText="保存中..."
                 size="lg"
                 w="full"
                 py={6}
@@ -606,7 +606,7 @@ export const Settings: React.FC = () => {
                 }}
                 transition="all 0.2s"
               >
-                💾 Save Preferences
+                💾 保存偏好
               </Button>
             </VStack>
           </CardBody>


### PR DESCRIPTION
## Summary
- update index.html language to Chinese
- translate header menu items
- add Chinese text in list pages and modals
- localize Settings page strings

## Testing
- `npm test` *(fails: jest not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688850184cfc8325adb2829e7c5474c1